### PR TITLE
looser dependency versions

### DIFF
--- a/darwin-libproc/Cargo.toml
+++ b/darwin-libproc/Cargo.toml
@@ -16,5 +16,5 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 darwin-libproc-sys = { version = "0.2", path = "../darwin-libproc-sys" }
-libc = "~0.2"
-memchr = "~2.3"
+libc = "0.2"
+memchr = "2.3"


### PR DESCRIPTION
Removes the '~' from dependency versions. 

The ['~' operator](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements) is much more restrictive than the default caret operator. 

I had conflicts on the memchr version because of your crate, even though I wasn' t even compiling it. I'm depending on `heim` while compiling for windows, and heim depends on your crate [only when compiling for macos](https://github.com/heim-rs/heim/blob/master/heim-process/Cargo.toml#L57), but because of [the way cargo resolves its dependencies](https://zulip-archive.rust-lang.org/246057tcargo/61263cargofailswithcfgdependencies.html), this still caused dependency resolution to fail.  